### PR TITLE
Path param

### DIFF
--- a/src/main/java/com/mercateo/rest/hateoas/client/impl/OngoingResponseImpl.java
+++ b/src/main/java/com/mercateo/rest/hateoas/client/impl/OngoingResponseImpl.java
@@ -160,26 +160,24 @@ public class OngoingResponseImpl<S> implements OngoingResponse<S> {
 		Map<String, String> pathParams = new HashMap<>();
 		UriTemplate uriTemplate = link.getHref();
 		List<String> vars = uriTemplate.getTemplateVariables();
-		if (vars.size() > 0) {
-			for (String var : vars) {
-				@SuppressWarnings("unchecked")
-				Set<Field> matchingFields = ReflectionUtils.getAllFields(requestObject.getClass(),
-						f -> f.getName().equals(var));
-				if (matchingFields.isEmpty()) {
-					throw new IllegalStateException("No field found for the template variable " + var);
-				} else if (matchingFields.size() != 1) {
-					throw new IllegalStateException("There is more than one field for the template variable " + var
-							+ ": " + matchingFields);
-				}
-				Field matchingField = matchingFields.iterator().next();
-				matchingField.setAccessible(true);
-				try {
-					pathParams.put(var, matchingField.get(requestObject).toString());
-				} catch (IllegalAccessException e) {
-					throw new ProcessingException(" Should never happen :-)");
-				}
+		vars.forEach(var -> {
+			@SuppressWarnings("unchecked")
+			Set<Field> matchingFields = ReflectionUtils.getAllFields(requestObject.getClass(),
+					f -> f.getName().equals(var));
+			if (matchingFields.isEmpty()) {
+				throw new IllegalStateException("No field found for the template variable " + var);
+			} else if (matchingFields.size() != 1) {
+				throw new IllegalStateException("There is more than one field for the template variable " + var
+						+ ": " + matchingFields);
 			}
-		}
+			Field matchingField = matchingFields.iterator().next();
+			matchingField.setAccessible(true);
+			try {
+				pathParams.put(var, matchingField.get(requestObject).toString());
+			} catch (IllegalAccessException e) {
+				throw new ProcessingException(" Should never happen :-)");
+			}
+		});
 		try {
 			return new URI(uriTemplate.createURI(pathParams));
 		} catch (URISyntaxException e) {


### PR DESCRIPTION
Don't fill path params only in case of method GET

If I want to PUT a new order via /orders/{id} with { "id":"0815", "article":"a book" } then path params must be mapped, too.

I guess they should be mapped for every method?!